### PR TITLE
Add DB session to subgrupo route

### DIFF
--- a/app/routers/router.py
+++ b/app/routers/router.py
@@ -1,12 +1,32 @@
 from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.database import SessionLocal
 from app.dependencies import get_current_user
+from app.schemas.schemas import Subgrupo, SubgrupoCreate
+from app.services import service
 
 router = APIRouter()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
 
 @router.get("/")
 def root():
     return {"message": "Welcome to GEM API"}
 
-@router.post("/subgrupos/create", dependencies=[Depends(get_current_user)])
-def create_subgrupo():
-    return {"message": "Subgrupo criado (apenas para admin autenticado)"}
+@router.post(
+    "/subgrupos/create",
+    response_model=Subgrupo,
+    dependencies=[Depends(get_current_user)],
+)
+def create_subgrupo(
+    subgrupo: SubgrupoCreate,
+    db: Session = Depends(get_db),
+):
+    return service.create_subgrupo(db, subgrupo)


### PR DESCRIPTION
## Summary
- inject SQLAlchemy Session in the subgrupo creation endpoint
- delegate creation to service.create_subgrupo and return created model

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683c9607186c8320a1a7128bf1c6126b