### PR TITLE
Implement CRUD routes for subgrupos & integrantes

### DIFF
--- a/app/routers/router.py
+++ b/app/routers/router.py
@@ -1,9 +1,15 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
+from typing import List
 
 from app.database import SessionLocal
 from app.dependencies import get_current_user
-from app.schemas.schemas import Subgrupo, SubgrupoCreate
+from app.schemas.schemas import (
+    Subgrupo,
+    SubgrupoCreate,
+    Integrante,
+    IntegranteCreate,
+)
 from app.services import service
 
 router = APIRouter()
@@ -24,9 +30,84 @@ def root():
     "/subgrupos/create",
     response_model=Subgrupo,
     dependencies=[Depends(get_current_user)],
+    tags=["Subgrupos"],
 )
 def create_subgrupo(
     subgrupo: SubgrupoCreate,
     db: Session = Depends(get_db),
 ):
     return service.create_subgrupo(db, subgrupo)
+
+
+@router.get("/subgrupos", response_model=List[Subgrupo], tags=["Subgrupos"])
+def read_subgrupos(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
+    return service.get_subgrupos(db, skip=skip, limit=limit)
+
+
+@router.get("/subgrupos/{id}", response_model=Subgrupo, tags=["Subgrupos"])
+def read_subgrupo(id: int, db: Session = Depends(get_db)):
+    return service.get_subgrupo(db, id)
+
+
+@router.put(
+    "/subgrupos/{id}",
+    response_model=Subgrupo,
+    dependencies=[Depends(get_current_user)],
+    tags=["Subgrupos"],
+)
+def update_subgrupo(id: int, subgrupo: SubgrupoCreate, db: Session = Depends(get_db)):
+    return service.update_subgrupo(db, id, subgrupo)
+
+
+@router.delete(
+    "/subgrupos/{id}",
+    response_model=Subgrupo,
+    dependencies=[Depends(get_current_user)],
+    tags=["Subgrupos"],
+)
+def delete_subgrupo(id: int, db: Session = Depends(get_db)):
+    return service.delete_subgrupo(db, id)
+
+
+@router.post(
+    "/integrantes",
+    response_model=Integrante,
+    dependencies=[Depends(get_current_user)],
+    tags=["Integrantes"],
+)
+def create_integrante(integrante: IntegranteCreate, db: Session = Depends(get_db)):
+    return service.create_integrante(db, integrante)
+
+
+@router.get("/integrantes", response_model=List[Integrante], tags=["Integrantes"])
+def read_integrantes(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
+    return service.get_integrantes(db, skip=skip, limit=limit)
+
+
+@router.get("/integrantes/{id}", response_model=Integrante, tags=["Integrantes"])
+def read_integrante(id: int, db: Session = Depends(get_db)):
+    return service.get_integrante(db, id)
+
+
+@router.put(
+    "/integrantes/{id}",
+    response_model=Integrante,
+    dependencies=[Depends(get_current_user)],
+    tags=["Integrantes"],
+)
+def update_integrante(
+    id: int,
+    integrante: IntegranteCreate,
+    db: Session = Depends(get_db),
+):
+    return service.update_integrante(db, id, integrante)
+
+
+@router.delete(
+    "/integrantes/{id}",
+    response_model=Integrante,
+    dependencies=[Depends(get_current_user)],
+    tags=["Integrantes"],
+)
+def delete_integrante(id: int, db: Session = Depends(get_db)):
+    return service.delete_integrante(db, id)

--- a/app/services/service.py
+++ b/app/services/service.py
@@ -13,6 +13,28 @@ def create_subgrupo(db: Session, subgrupo: SubgrupoCreate):
 def get_subgrupos(db: Session, skip: int = 0, limit: int = 10):
     return db.query(models.Subgrupo).offset(skip).limit(limit).all()
 
+def get_subgrupo(db: Session, subgrupo_id: int):
+    return (
+        db.query(models.Subgrupo)
+        .filter(models.Subgrupo.id_subgrupo == subgrupo_id)
+        .first()
+    )
+
+def update_subgrupo(db: Session, subgrupo_id: int, subgrupo: SubgrupoCreate):
+    db_subgrupo = db.query(models.Subgrupo).filter(models.Subgrupo.id_subgrupo == subgrupo_id).first()
+    if db_subgrupo:
+        db_subgrupo.nome_subgrupo = subgrupo.nome_subgrupo
+        db.commit()
+        db.refresh(db_subgrupo)
+    return db_subgrupo
+
+def delete_subgrupo(db: Session, subgrupo_id: int):
+    db_subgrupo = db.query(models.Subgrupo).filter(models.Subgrupo.id_subgrupo == subgrupo_id).first()
+    if db_subgrupo:
+        db.delete(db_subgrupo)
+        db.commit()
+    return db_subgrupo
+
 def create_integrante(db: Session, integrante: IntegranteCreate):
     hashed_password = bcrypt.hashpw(
         integrante.password.encode(), bcrypt.gensalt()
@@ -30,3 +52,29 @@ def create_integrante(db: Session, integrante: IntegranteCreate):
 
 def get_integrantes(db: Session, skip: int = 0, limit: int = 10):
     return db.query(models.Integrante).offset(skip).limit(limit).all()
+
+def get_integrante(db: Session, integrante_id: int):
+    return (
+        db.query(models.Integrante)
+        .filter(models.Integrante.id_integrante == integrante_id)
+        .first()
+    )
+
+def update_integrante(db: Session, integrante_id: int, integrante: IntegranteCreate):
+    db_integrante = db.query(models.Integrante).filter(models.Integrante.id_integrante == integrante_id).first()
+    if db_integrante:
+        hashed_password = bcrypt.hashpw(integrante.password.encode(), bcrypt.gensalt()).decode()
+        db_integrante.nome_integrante = integrante.nome_integrante
+        db_integrante.e_mail_integrante = integrante.e_mail_integrante
+        db_integrante.password = hashed_password
+        db_integrante.id_subgrupo = integrante.id_subgrupo
+        db.commit()
+        db.refresh(db_integrante)
+    return db_integrante
+
+def delete_integrante(db: Session, integrante_id: int):
+    db_integrante = db.query(models.Integrante).filter(models.Integrante.id_integrante == integrante_id).first()
+    if db_integrante:
+        db.delete(db_integrante)
+        db.commit()
+    return db_integrante


### PR DESCRIPTION
## Summary
- extend service layer with update/delete helpers
- expose CRUD API endpoints for `Subgrupos` and `Integrantes`
- secure mutation routes using `get_current_user`
- categorize Swagger docs via tags

## Testing
- `python -m py_compile app/services/service.py app/routers/router.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683c979fd19c8320b99faa7533622167